### PR TITLE
fix: optimize handling of remote PDF files

### DIFF
--- a/include/dpdfdoc.h
+++ b/include/dpdfdoc.h
@@ -141,6 +141,18 @@ private:
      */
     bool isLinearized(const QString &fileName);
 
+    /**
+     * @brief Save local file
+     * @return
+     */
+    bool saveLocalFile();
+
+    /**
+     * @brief Save remote file
+     * @return
+     */
+    bool saveRemoteFile();
+
 private:
     Q_DISABLE_COPY(DPdfDoc)
     QScopedPointer<DPdfDocPrivate> d_ptr;


### PR DESCRIPTION
Improves the way the application handles PDF files located on remote filesystems like SMB:

1. Add detection of remote files using filesystem type checking
2. Create local copies of remote files in a dedicated cache directory
3. Implement a new save strategy for remote files:
   - Avoid file deletion which causes issues on SMB filesystems
   - Use saveAs() method to directly write to destination

Log: Added support for handling remote files and saving them appropriately.

bug: https://pms.uniontech.com/bug-view-314071.html